### PR TITLE
Migrate to ESLint flat config (eslint-config-domdomegg v2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript", "eslint-config-domdomegg"],
-  "rules": {
-    "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useButtonListener)"
-    }]
-  }
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,26 @@
+import domdomegg from 'eslint-config-domdomegg';
+import next from '@next/eslint-plugin-next';
+
+/** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigFile} */
+export default [
+	{
+		ignores: ['.next/**', 'out/**', 'next-env.d.ts'],
+	},
+	{
+		plugins: {
+			'@next/next': next,
+		},
+		rules: {
+			...next.configs.recommended.rules,
+			...next.configs['core-web-vitals'].rules,
+		},
+	},
+	...domdomegg,
+	{
+		rules: {
+			'react-hooks/exhaustive-deps': ['warn', {
+				additionalHooks: '(useButtonListener)',
+			}],
+		},
+	},
+];

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,14 @@
-import type { NextConfig } from "next";
+import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
-  output: 'export',
-  distDir: 'dist',
-  reactStrictMode: true,
-  images: {
-    unoptimized: true,
-  },
-  trailingSlash: true,
-  assetPrefix: process.env.NODE_ENV === 'production' ? './' : undefined,
+	output: 'export',
+	distDir: 'dist',
+	reactStrictMode: true,
+	images: {
+		unoptimized: true,
+	},
+	trailingSlash: true,
+	assetPrefix: process.env.NODE_ENV === 'production' ? './' : undefined,
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
+        "@next/eslint-plugin-next": "^16.2.6",
         "@types/node": "^22.15.32",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
-        "eslint": "^10",
-        "eslint-config-next": "15.0.2",
+        "eslint": "^9.0.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.8.3"
@@ -39,33 +39,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -100,41 +77,143 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -150,31 +229,34 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/types": "^0.15.0"
@@ -187,6 +269,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.2",
@@ -201,6 +284,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -210,6 +294,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -223,6 +308,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -751,25 +837,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@next/env": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
@@ -777,9 +844,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.2.tgz",
-      "integrity": "sha512-R9Jc7T6Ge0txjmqpPwqD8vx6onQjynO9JT73ArCYiYPvSrwYXepH/UY/WdKDY8JPWJl72sAE4iGMHPeQ5xdEWg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -952,30 +1019,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nolyfill/is-core-module": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@rtsao/scc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
-      "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
@@ -1007,23 +1050,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -1044,39 +1070,17 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1171,23 +1175,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
@@ -1207,23 +1194,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -1283,23 +1253,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
@@ -1338,23 +1291,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1409,349 +1345,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
-      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
-      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
-      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
-      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
-      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
-      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
-      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
-      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
-      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
-      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
-      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
-      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
-      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
-      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
-      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
-      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
-      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
-      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
-      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
-      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
-      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
-      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1777,6 +1370,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1787,6 +1381,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1816,6 +1426,13 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -1876,28 +1493,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
-      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2130,6 +1725,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2159,6 +1764,23 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2213,6 +1835,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2239,6 +1881,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2326,9 +1969,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2346,6 +1989,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/define-data-property": {
@@ -2632,6 +2276,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2641,32 +2286,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2676,7 +2322,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2684,7 +2331,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -2848,272 +2495,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-config-next": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.2.tgz",
-      "integrity": "sha512-N8o6cyUXzlMmQbdc2Kc83g1qomFi3ITqrAZfubipVKET2uR2mCStyGRcx/r8WiAIVMul2KfwRiCHBkTpBvGBmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@next/eslint-plugin-next": "15.0.2",
-        "@rushstack/eslint-patch": "^1.10.3",
-        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jsx-a11y": "^6.10.0",
-        "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-react-hooks": "^5.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
-        "typescript": ">=3.3.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
-      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@nolyfill/is-core-module": "1.0.39",
-        "debug": "^4.4.0",
-        "get-tsconfig": "^4.10.0",
-        "is-bun-module": "^2.0.0",
-        "stable-hash": "^0.0.5",
-        "tinyglobby": "^0.2.13",
-        "unrs-resolver": "^1.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-import-resolver-typescript"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-import-x": "*"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-import": {
-          "optional": true
-        },
-        "eslint-plugin-import-x": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.9",
-        "array.prototype.findlastindex": "^1.2.6",
-        "array.prototype.flat": "^1.3.3",
-        "array.prototype.flatmap": "^1.3.3",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.1",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.16.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.1",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.9",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
-      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aria-query": "^5.3.2",
-        "array-includes": "^3.1.8",
-        "array.prototype.flatmap": "^1.3.2",
-        "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.10.0",
-        "axobject-query": "^4.1.0",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^3.3.5",
-        "language-tags": "^1.0.9",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.includes": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
-      "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/eslint-config-xo": {
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.46.0.tgz",
@@ -3155,69 +2536,18 @@
         "typescript": ">=5.5.0"
       }
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3235,42 +2565,74 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "license": "BSD-2-Clause",
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3280,6 +2642,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3292,6 +2655,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -3322,6 +2686,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3358,12 +2723,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -3380,6 +2747,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -3405,6 +2773,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -3421,6 +2790,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -3434,6 +2804,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -3570,23 +2941,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3645,6 +3004,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -3717,15 +3086,34 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -3825,16 +3213,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-bun-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
-      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.7.1"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -3914,6 +3292,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3957,6 +3336,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4161,6 +3541,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4184,7 +3565,7 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -4196,36 +3577,49 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
+      "license": "MIT"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -4246,6 +3640,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4273,6 +3668,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -4303,6 +3699,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -4313,6 +3710,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4374,16 +3778,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4418,22 +3812,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/napi-postinstall": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "napi-postinstall": "lib/cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/napi-postinstall"
       }
     },
     "node_modules/natural-compare": {
@@ -4653,21 +4031,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.groupby": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
@@ -4690,6 +4053,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -4724,6 +4088,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -4739,6 +4104,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -4750,10 +4116,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4763,6 +4143,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4989,6 +4370,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -5009,6 +4391,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5145,14 +4528,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -5355,6 +4738,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5367,6 +4751,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5452,13 +4837,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/stable-hash": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
-      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5581,14 +4959,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/styled-jsx": {
@@ -5635,6 +5016,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -5787,19 +5181,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5810,6 +5191,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -5896,6 +5278,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5953,48 +5336,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unrs-resolver": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
-      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "napi-postinstall": "^0.3.4"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unrs-resolver"
-      },
-      "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
-        "@unrs/resolver-binding-android-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-x64": "1.12.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
-        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6011,6 +5357,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6111,6 +5458,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6133,6 +5481,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "next dev --turbopack",
     "build": "next build",
-    "lint": "eslint src/",
+    "lint": "eslint",
     "dev": "npm start"
   },
   "dependencies": {
@@ -17,11 +17,11 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^16.2.6",
     "@types/node": "^22.15.32",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "eslint": "^10",
-    "eslint-config-next": "15.0.2",
+    "eslint": "^9.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.3"

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,8 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: {
-    tailwindcss: {},
-  },
+	plugins: {
+		tailwindcss: {},
+	},
 };
 
 export default config;

--- a/src/components/AnimationEffectRenderer.tsx
+++ b/src/components/AnimationEffectRenderer.tsx
@@ -1,58 +1,65 @@
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import {useEffect, useState} from 'react';
 import clsx from 'clsx';
 
 export type AnimationEffect = {
-  id: number;
-  type: 'floatingScore' | 'bonus';
-  score?: number;
-  text?: string;
+	id: number;
+	type: 'floatingScore' | 'bonus';
+	score?: number;
+	text?: string;
 };
 
-interface Props {
-  effect: AnimationEffect;
-  onComplete: () => void;
-}
+type Props = {
+	effect: AnimationEffect;
+	onComplete: () => void;
+};
 
 const AnimationEffectRenderer: React.FC<Props> = ({
-  effect, onComplete,
+	effect, onComplete,
 }) => {
-  const [isVisible, setIsVisible] = useState(false);
-  const [offset] = useState({ x: (Math.random() * 200) - 100, y: (Math.random() * 60) + 30 });
+	const [isVisible, setIsVisible] = useState(false);
+	const [offset] = useState({x: (Math.random() * 200) - 100, y: (Math.random() * 60) + 30});
 
-  // Trigger load in animations
-  useEffect(() => {
-    setTimeout(() => setIsVisible(true), 50);
-  }, []);
+	// Trigger load in animations
+	useEffect(() => {
+		setTimeout(() => {
+			setIsVisible(true);
+		}, 50);
+	}, []);
 
-  // Disappear after a delay
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsVisible(false);
-      setTimeout(() => onComplete(), 200); // Wait for fade out
-    }, 800);
+	// Disappear after a delay
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setIsVisible(false);
+			setTimeout(() => {
+				onComplete();
+			}, 200); // Wait for fade out
+		}, 800);
 
-    return () => clearTimeout(timer);
-  }, []);
+		return () => {
+			clearTimeout(timer);
+		};
+	}, []);
 
-  // eslint-disable-next-line no-nested-ternary
-  const colorClass = effect.score !== undefined ? (effect.score > 0 ? 'text-green-400' : 'text-red-400')
-    : 'text-yellow-400';
+	const colorClass = effect.score !== undefined
+		? (effect.score > 0 ? 'text-green-400' : 'text-red-400')
+		: 'text-yellow-400';
 
-  return (
-    <div
-      className={clsx(
-        'absolute pointer-events-none z-40 font-bold text-2xl transition-all -translate-x-1/2',
-        isVisible ? 'opacity-100 -translate-y-16' : 'opacity-0 -translate-y-8 scale-0',
-        colorClass,
-      )}
-      style={{
-        left: `${offset.x}px`,
-        top: `${offset.y}px`,
-      }}
-    >
-      {effect.score !== undefined ? `${effect.score > 0 ? '+' : ''}${effect.score}` : effect.text}
-    </div>
-  );
+	return (
+		<div
+			className={clsx(
+				'absolute pointer-events-none z-40 font-bold text-2xl transition-all -translate-x-1/2',
+				isVisible ? 'opacity-100 -translate-y-16' : 'opacity-0 -translate-y-8 scale-0',
+				colorClass,
+			)}
+			style={{
+				left: `${offset.x}px`,
+				top: `${offset.y}px`,
+			}}
+		>
+			{effect.score !== undefined ? `${effect.score > 0 ? '+' : ''}${effect.score}` : effect.text}
+		</div>
+	);
 };
 
 export default AnimationEffectRenderer;

--- a/src/components/ButtonsLayout.tsx
+++ b/src/components/ButtonsLayout.tsx
@@ -1,29 +1,29 @@
-import React from 'react';
+import type React from 'react';
 import clsx from 'clsx';
-import { ButtonType } from '../types/game';
+import {type ButtonType} from '../types/game';
 import ControllerButton from './ControllerButton';
 
-interface Props {
-  sequence: ButtonType[];
-  completedButtons: ButtonType[];
-}
+type Props = {
+	sequence: ButtonType[];
+	completedButtons: ButtonType[];
+};
 
-const ButtonsLayout: React.FC<Props> = ({ sequence, completedButtons }) => {
-  return (
-    <div className="h-80 w-full bg-gray-900 rounded-lg border-2 border-gray-700">
-      <div className="flex justify-center items-center h-full gap-8">
-        {sequence.map((button, index) => (
-          <ControllerButton
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${button}-${index}`}
-            button={button}
-            className={clsx(index === completedButtons.length && 'scale-125', index > completedButtons.length && 'opacity-60')}
-            disabled={index < completedButtons.length}
-          />
-        ))}
-      </div>
-    </div>
-  );
+const ButtonsLayout: React.FC<Props> = ({sequence, completedButtons}) => {
+	return (
+		<div className='h-80 w-full bg-gray-900 rounded-lg border-2 border-gray-700'>
+			<div className='flex justify-center items-center h-full gap-8'>
+				{sequence.map((button, index) => (
+					<ControllerButton
+
+						key={`${button}-${index}`}
+						button={button}
+						className={clsx(index === completedButtons.length && 'scale-125', index > completedButtons.length && 'opacity-60')}
+						disabled={index < completedButtons.length}
+					/>
+				))}
+			</div>
+		</div>
+	);
 };
 
 export default ButtonsLayout;

--- a/src/components/ConfettiCelebration.tsx
+++ b/src/components/ConfettiCelebration.tsx
@@ -1,87 +1,88 @@
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import {useEffect, useState} from 'react';
 
-interface ConfettiPiece {
-  id: number;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  rotation: number;
-  rotationSpeed: number;
-  color: string;
-  size: number;
-}
+type ConfettiPiece = {
+	id: number;
+	x: number;
+	y: number;
+	vx: number;
+	vy: number;
+	rotation: number;
+	rotationSpeed: number;
+	color: string;
+	size: number;
+};
 
-interface Props {
-  onComplete: () => void;
-}
+type Props = {
+	onComplete: () => void;
+};
 
-const ConfettiCelebration: React.FC<Props> = ({ onComplete }) => {
-  const [confetti, setConfetti] = useState<ConfettiPiece[]>([]);
+const ConfettiCelebration: React.FC<Props> = ({onComplete}) => {
+	const [confetti, setConfetti] = useState<ConfettiPiece[]>([]);
 
-  useEffect(() => {
-    // Create confetti pieces
-    const pieces: ConfettiPiece[] = [];
-    const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#feca57', '#ff9ff3', '#54a0ff'];
+	useEffect(() => {
+		// Create confetti pieces
+		const pieces: ConfettiPiece[] = [];
+		const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#feca57', '#ff9ff3', '#54a0ff'];
 
-    for (let i = 0; i < 100; i++) {
-      pieces.push({
-        id: i,
-        x: Math.random() * window.innerWidth,
-        y: -10 - Math.random() * 400,
-        vx: (Math.random() - 0.5) * 4,
-        vy: Math.random() * 3 + 2,
-        rotation: Math.random() * 360,
-        rotationSpeed: (Math.random() - 0.5) * 10,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        size: Math.random() * 8 + 4,
-      });
-    }
+		for (let i = 0; i < 100; i++) {
+			pieces.push({
+				id: i,
+				x: Math.random() * window.innerWidth,
+				y: -10 - (Math.random() * 400),
+				vx: (Math.random() - 0.5) * 4,
+				vy: (Math.random() * 3) + 2,
+				rotation: Math.random() * 360,
+				rotationSpeed: (Math.random() - 0.5) * 10,
+				color: colors[Math.floor(Math.random() * colors.length)],
+				size: (Math.random() * 8) + 4,
+			});
+		}
 
-    setConfetti(pieces);
+		setConfetti(pieces);
 
-    // Animation loop
-    const animate = () => {
-      setConfetti((prev) => prev.map((piece) => ({
-        ...piece,
-        x: piece.x + piece.vx,
-        y: piece.y + piece.vy,
-        vy: piece.vy + 0.1, // gravity
-        rotation: piece.rotation + piece.rotationSpeed,
-      })).filter((piece) => piece.y < window.innerHeight + 50));
-    };
+		// Animation loop
+		const animate = () => {
+			setConfetti((prev) => prev.map((piece) => ({
+				...piece,
+				x: piece.x + piece.vx,
+				y: piece.y + piece.vy,
+				vy: piece.vy + 0.1, // gravity
+				rotation: piece.rotation + piece.rotationSpeed,
+			})).filter((piece) => piece.y < window.innerHeight + 50));
+		};
 
-    const interval = setInterval(animate, 16);
-    const timeout = setTimeout(() => {
-      clearInterval(interval);
-      onComplete();
-    }, 3000);
+		const interval = setInterval(animate, 16);
+		const timeout = setTimeout(() => {
+			clearInterval(interval);
+			onComplete();
+		}, 3000);
 
-    return () => {
-      clearInterval(interval);
-      clearTimeout(timeout);
-    };
-  }, []);
+		return () => {
+			clearInterval(interval);
+			clearTimeout(timeout);
+		};
+	}, []);
 
-  return (
-    <div className="fixed inset-0 pointer-events-none z-50">
-      {confetti.map((piece) => (
-        <div
-          key={piece.id}
-          className="absolute"
-          style={{
-            left: piece.x,
-            top: piece.y,
-            width: piece.size,
-            height: piece.size,
-            backgroundColor: piece.color,
-            transform: `rotate(${piece.rotation}deg)`,
-            borderRadius: Math.random() > 0.5 ? '50%' : '0%',
-          }}
-        />
-      ))}
-    </div>
-  );
+	return (
+		<div className='fixed inset-0 pointer-events-none z-50'>
+			{confetti.map((piece) => (
+				<div
+					key={piece.id}
+					className='absolute'
+					style={{
+						left: piece.x,
+						top: piece.y,
+						width: piece.size,
+						height: piece.size,
+						backgroundColor: piece.color,
+						transform: `rotate(${piece.rotation}deg)`,
+						borderRadius: Math.random() > 0.5 ? '50%' : '0%',
+					}}
+				/>
+			))}
+		</div>
+	);
 };
 
 export default ConfettiCelebration;

--- a/src/components/ControllerButton.tsx
+++ b/src/components/ControllerButton.tsx
@@ -1,33 +1,33 @@
-import React from 'react';
+import type React from 'react';
 import clsx from 'clsx';
-import { ButtonType } from '../types/game';
+import {type ButtonType} from '../types/game';
 
-interface Props {
-  button: ButtonType;
-  className?: string;
-  disabled?: boolean;
-}
+type Props = {
+	button: ButtonType;
+	className?: string;
+	disabled?: boolean;
+};
 
 const ControllerButton: React.FC<Props> = ({
-  button,
-  disabled = false,
-  className = '',
+	button,
+	disabled = false,
+	className = '',
 }) => {
-  return (
-    <div className={clsx(
-      'relative w-16 h-16 transition-all duration-300',
-      disabled ? 'opacity-10' : 'opacity-100',
-      className,
-    )}
-    >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={`./xbox_${button}.svg`}
-        alt={`${button} button`}
-        className="object-contain h-full w-full"
-      />
-    </div>
-  );
+	return (
+		<div className={clsx(
+			'relative w-16 h-16 transition-all duration-300',
+			disabled ? 'opacity-10' : 'opacity-100',
+			className,
+		)}
+		>
+			{/* eslint-disable-next-line @next/next/no-img-element */}
+			<img
+				src={`./xbox_${button}.svg`}
+				alt={`${button} button`}
+				className='object-contain h-full w-full'
+			/>
+		</div>
+	);
 };
 
 export default ControllerButton;

--- a/src/components/CreditsScreen.tsx
+++ b/src/components/CreditsScreen.tsx
@@ -1,41 +1,41 @@
-import React from 'react';
-import { useGamepad } from '../contexts/GamepadContext';
+import type React from 'react';
+import {useGamepad} from '../contexts/GamepadContext';
 import ControllerButton from './ControllerButton';
 
-interface Props {
-  onBackToMenu: () => void;
-}
+type Props = {
+	onBackToMenu: () => void;
+};
 
-const CreditsScreen: React.FC<Props> = ({ onBackToMenu }) => {
-  const { useButtonListener } = useGamepad();
+const CreditsScreen: React.FC<Props> = ({onBackToMenu}) => {
+	const {useButtonListener} = useGamepad();
 
-  // Handle gamepad input
-  useButtonListener((button) => {
-    if (button === 'B') {
-      onBackToMenu();
-    }
-  }, [onBackToMenu]);
+	// Handle gamepad input
+	useButtonListener((button) => {
+		if (button === 'B') {
+			onBackToMenu();
+		}
+	}, [onBackToMenu]);
 
-  return (
-    <div className="flex flex-col items-start justify-center min-h-screen bg-gray-900 text-white p-16">
-      <h2 className="text-4xl font-bold mb-12">Credits</h2>
+	return (
+		<div className='flex flex-col items-start justify-center min-h-screen bg-gray-900 text-white p-16'>
+			<h2 className='text-4xl font-bold mb-12'>Credits</h2>
 
-      <div className="space-y-6 text-lg max-w-2xl">
-        <p>Game built by <a href="https://adamjones.me/" className="text-blue-400 hover:text-blue-300 underline">Adam Jones</a>, with a lot of help from Anthropic's Claude in <a href="https://github.com/cline/cline" className="text-blue-400 hover:text-blue-300 underline">Cline</a></p>
+			<div className='space-y-6 text-lg max-w-2xl'>
+				<p>Game built by <a href='https://adamjones.me/' className='text-blue-400 hover:text-blue-300 underline'>Adam Jones</a>, with a lot of help from Anthropic's Claude in <a href='https://github.com/cline/cline' className='text-blue-400 hover:text-blue-300 underline'>Cline</a></p>
 
-        <p>Inspired by <a href="https://malenaschmidt.com/" className="text-blue-400 hover:text-blue-300 underline">Malena Schmidt</a>'s inability to remember where buttons are</p>
+				<p>Inspired by <a href='https://malenaschmidt.com/' className='text-blue-400 hover:text-blue-300 underline'>Malena Schmidt</a>'s inability to remember where buttons are</p>
 
-        <p>Controller icons by <a href="https://kenney.nl" className="text-blue-400 hover:text-blue-300 underline">Kenney</a></p>
+				<p>Controller icons by <a href='https://kenney.nl' className='text-blue-400 hover:text-blue-300 underline'>Kenney</a></p>
 
-        <p>Source code on <a href="https://github.com/domdomegg/controller-tutor/" className="text-blue-400 hover:text-blue-300 underline">GitHub</a></p>
-      </div>
+				<p>Source code on <a href='https://github.com/domdomegg/controller-tutor/' className='text-blue-400 hover:text-blue-300 underline'>GitHub</a></p>
+			</div>
 
-      <div className="mt-12 flex items-center">
-        <ControllerButton button="B" />
-        <span className="ml-2 text-xl">Return to Menu</span>
-      </div>
-    </div>
-  );
+			<div className='mt-12 flex items-center'>
+				<ControllerButton button='B' />
+				<span className='ml-2 text-xl'>Return to Menu</span>
+			</div>
+		</div>
+	);
 };
 
 export default CreditsScreen;

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,211 +1,222 @@
-import React, {
-  useState, useEffect, useCallback, useRef,
+import type React from 'react';
+import {
+	useState, useEffect, useCallback, useRef,
 } from 'react';
-import { ButtonType, GameStatus } from '../types/game';
+import {type ButtonType, type GameStatus} from '../types/game';
 import ButtonsLayout from './ButtonsLayout';
-import { useGamepad } from '../contexts/GamepadContext';
+import {useGamepad} from '../contexts/GamepadContext';
 import PlayArea from './PlayArea';
 import ScreenEffects from './ScreenEffects';
-import AnimationEffectRenderer, { AnimationEffect } from './AnimationEffectRenderer';
+import AnimationEffectRenderer, {type AnimationEffect} from './AnimationEffectRenderer';
 import ConfettiCelebration from './ConfettiCelebration';
 
-interface Props {
-  onGameOver: (finalScore: number) => void;
-}
+type Props = {
+	onGameOver: (finalScore: number) => void;
+};
 
 const SEQUENCE_LENGTH = 6;
 const PRESS_BUTTON_TYPES: ButtonType[] = ['A', 'B', 'X', 'Y', 'LB', 'RB', 'LT', 'RT'];
 const STICK_AND_DIRECTION_BUTTON_TYPES: ButtonType[] = ['LS', 'RS', 'DUp', 'DDown', 'DLeft', 'DRight', 'LUp', 'LDown', 'LLeft', 'LRight', 'RUp', 'RDown', 'RLeft', 'RRight'];
 
 const generateSequence = (length: number): ButtonType[] => {
-  const sequence: ButtonType[] = [];
-  for (let i = 0; i < length; i++) {
-    const buttonTypes = Math.random() > 0.15 ? PRESS_BUTTON_TYPES : STICK_AND_DIRECTION_BUTTON_TYPES;
-    sequence.push(buttonTypes[Math.floor(Math.random() * buttonTypes.length)]);
-  }
-  return sequence;
+	const sequence: ButtonType[] = [];
+	for (let i = 0; i < length; i++) {
+		const buttonTypes = Math.random() > 0.15 ? PRESS_BUTTON_TYPES : STICK_AND_DIRECTION_BUTTON_TYPES;
+		sequence.push(buttonTypes[Math.floor(Math.random() * buttonTypes.length)]);
+	}
+
+	return sequence;
 };
 
-const GameScreen: React.FC<Props> = ({ onGameOver }) => {
-  const [gameStatus, setGameStatus] = useState<GameStatus>({
-    currentScore: 0,
-    currentSequence: generateSequence(SEQUENCE_LENGTH),
-    completedButtons: [],
-    totalRoundTime: 30_000,
-    roundTimeRemaining: 30_000,
-  });
+const GameScreen: React.FC<Props> = ({onGameOver}) => {
+	const [gameStatus, setGameStatus] = useState<GameStatus>({
+		currentScore: 0,
+		currentSequence: generateSequence(SEQUENCE_LENGTH),
+		completedButtons: [],
+		totalRoundTime: 30_000,
+		roundTimeRemaining: 30_000,
+	});
 
-  // Animation states
-  const [showErrorFlash, setShowErrorFlash] = useState(false);
-  const [showConfetti, setShowConfetti] = useState(false);
-  const [animationEffects, setAnimationEffects] = useState<AnimationEffect[]>([]);
-  const [lastPressTime, setLastPressTime] = useState<number>(0);
-  const [consecutiveCorrect, setConsecutiveCorrect] = useState(0);
-  const effectIdCounter = useRef(0);
+	// Animation states
+	const [showErrorFlash, setShowErrorFlash] = useState(false);
+	const [showConfetti, setShowConfetti] = useState(false);
+	const [animationEffects, setAnimationEffects] = useState<AnimationEffect[]>([]);
+	const [lastPressTime, setLastPressTime] = useState<number>(0);
+	const [consecutiveCorrect, setConsecutiveCorrect] = useState(0);
+	const effectIdCounter = useRef(0);
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setGameStatus((prev) => {
-        if (prev.roundTimeRemaining <= 0) {
-          clearInterval(timer);
-          onGameOver(prev.currentScore);
-          return prev;
-        }
-        return { ...prev, roundTimeRemaining: prev.roundTimeRemaining - 100 };
-      });
-    }, 100);
+	useEffect(() => {
+		const timer = setInterval(() => {
+			setGameStatus((prev) => {
+				if (prev.roundTimeRemaining <= 0) {
+					clearInterval(timer);
+					onGameOver(prev.currentScore);
+					return prev;
+				}
 
-    return () => clearInterval(timer);
-  }, [onGameOver]);
+				return {...prev, roundTimeRemaining: prev.roundTimeRemaining - 100};
+			});
+		}, 100);
 
-  const { useButtonListener, rumble } = useGamepad();
+		return () => {
+			clearInterval(timer);
+		};
+	}, [onGameOver]);
 
-  // Helper functions for animations
-  const addAnimationEffect = useCallback((type: AnimationEffect['type'], opts?: { score?: number, text?: string }) => {
-    const newEffect: AnimationEffect = {
-      // eslint-disable-next-line no-plusplus
-      id: effectIdCounter.current++,
-      type,
-      score: opts?.score,
-      text: opts?.text,
-    };
-    setAnimationEffects((prev) => [...prev, newEffect]);
-  }, []);
+	const {useButtonListener, rumble} = useGamepad();
 
-  const removeAnimationEffect = useCallback((id: number) => {
-    setAnimationEffects((prev) => {
-      return prev.filter((effect) => effect.id !== id);
-    });
-  }, [setAnimationEffects]);
+	// Helper functions for animations
+	const addAnimationEffect = useCallback((type: AnimationEffect['type'], opts?: {score?: number; text?: string}) => {
+		const newEffect: AnimationEffect = {
+			// eslint-disable-next-line no-plusplus
+			id: effectIdCounter.current++,
+			type,
+			score: opts?.score,
+			text: opts?.text,
+		};
+		setAnimationEffects((prev) => [...prev, newEffect]);
+	}, []);
 
-  const triggerErrorEffects = useCallback(() => {
-    setShowErrorFlash(true);
-    setTimeout(() => setShowErrorFlash(false), 1000);
-  }, []);
+	const removeAnimationEffect = useCallback((id: number) => {
+		setAnimationEffects((prev) => {
+			return prev.filter((effect) => effect.id !== id);
+		});
+	}, [setAnimationEffects]);
 
-  // Handle gamepad input
-  useButtonListener((button) => {
-    const {
-      currentSequence, completedButtons, currentScore, totalRoundTime, roundTimeRemaining,
-    } = gameStatus;
-    const currentButton = currentSequence[completedButtons.length];
-    const now = Date.now();
+	const triggerErrorEffects = useCallback(() => {
+		setShowErrorFlash(true);
+		setTimeout(() => {
+			setShowErrorFlash(false);
+		}, 1000);
+	}, []);
 
-    if (button === currentButton) {
-      // Add particle explosion and floating score
-      addAnimationEffect('floatingScore', { score: 100 });
+	// Handle gamepad input
+	useButtonListener((button) => {
+		const {
+			currentSequence, completedButtons, currentScore, totalRoundTime, roundTimeRemaining,
+		} = gameStatus;
+		const currentButton = currentSequence[completedButtons.length];
+		const now = Date.now();
 
-      // Track timing for bonuses
-      const timeSinceLastPress = now - lastPressTime;
-      setLastPressTime(now);
+		if (button === currentButton) {
+			// Add particle explosion and floating score
+			addAnimationEffect('floatingScore', {score: 100});
 
-      if (timeSinceLastPress < 500 && lastPressTime > 0) {
-        setConsecutiveCorrect((prev) => prev + 1);
-        if (consecutiveCorrect >= 2) {
-          addAnimationEffect('bonus', { text: 'COMBO!' });
-        }
-      } else {
-        setConsecutiveCorrect(1);
-      }
+			// Track timing for bonuses
+			const timeSinceLastPress = now - lastPressTime;
+			setLastPressTime(now);
 
-      if (currentSequence.length === completedButtons.length + 1) {
-        // Sequence completed!
-        const timeBonus = Math.floor(roundTimeRemaining / 10);
-        const totalPoints = 100 + timeBonus;
+			if (timeSinceLastPress < 500 && lastPressTime > 0) {
+				setConsecutiveCorrect((prev) => prev + 1);
+				if (consecutiveCorrect >= 2) {
+					addAnimationEffect('bonus', {text: 'COMBO!'});
+				}
+			} else {
+				setConsecutiveCorrect(1);
+			}
 
-        // Check for perfect bonus (>75% time remaining)
-        if (roundTimeRemaining > totalRoundTime * 0.75) {
-          addAnimationEffect('bonus', { text: 'PERFECT!' });
-        }
+			if (currentSequence.length === completedButtons.length + 1) {
+				// Sequence completed!
+				const timeBonus = Math.floor(roundTimeRemaining / 10);
+				const totalPoints = 100 + timeBonus;
 
-        // Show confetti
-        setShowConfetti(true);
+				// Check for perfect bonus (>75% time remaining)
+				if (roundTimeRemaining > totalRoundTime * 0.75) {
+					addAnimationEffect('bonus', {text: 'PERFECT!'});
+				}
 
-        // Reduce the time for next round
-        const nextRoundTime = Math.floor(totalRoundTime * (totalRoundTime > 10_000 ? 0.75 : 0.95));
+				// Show confetti
+				setShowConfetti(true);
 
-        setGameStatus({
-          currentScore: currentScore + totalPoints,
-          currentSequence: generateSequence(SEQUENCE_LENGTH),
-          completedButtons: [],
-          totalRoundTime: nextRoundTime,
-          roundTimeRemaining: nextRoundTime,
-        });
+				// Reduce the time for next round
+				const nextRoundTime = Math.floor(totalRoundTime * (totalRoundTime > 10_000 ? 0.75 : 0.95));
 
-        // Clear all animation effects when starting new sequence
-        setAnimationEffects([]);
-      } else {
-        // Button correctly pressed
-        setGameStatus({
-          ...gameStatus,
-          currentScore: currentScore + 100,
-          completedButtons: [...completedButtons, button],
-        });
-      }
-    } else {
-      // Incorrect button press penalty
-      rumble();
-      triggerErrorEffects();
-      setConsecutiveCorrect(0);
+				setGameStatus({
+					currentScore: currentScore + totalPoints,
+					currentSequence: generateSequence(SEQUENCE_LENGTH),
+					completedButtons: [],
+					totalRoundTime: nextRoundTime,
+					roundTimeRemaining: nextRoundTime,
+				});
 
-      // Add floating score for penalty
-      addAnimationEffect('floatingScore', { score: -25 });
+				// Clear all animation effects when starting new sequence
+				setAnimationEffects([]);
+			} else {
+				// Button correctly pressed
+				setGameStatus({
+					...gameStatus,
+					currentScore: currentScore + 100,
+					completedButtons: [...completedButtons, button],
+				});
+			}
+		} else {
+			// Incorrect button press penalty
+			rumble();
+			triggerErrorEffects();
+			setConsecutiveCorrect(0);
 
-      setGameStatus({
-        ...gameStatus,
-        currentScore: Math.max(0, currentScore - 25),
-      });
-    }
-  }, [gameStatus, setGameStatus, lastPressTime, consecutiveCorrect, addAnimationEffect, triggerErrorEffects, rumble]);
+			// Add floating score for penalty
+			addAnimationEffect('floatingScore', {score: -25});
 
-  const timePercentage = (gameStatus.roundTimeRemaining / gameStatus.totalRoundTime) * 100;
+			setGameStatus({
+				...gameStatus,
+				currentScore: Math.max(0, currentScore - 25),
+			});
+		}
+	}, [gameStatus, setGameStatus, lastPressTime, consecutiveCorrect, addAnimationEffect, triggerErrorEffects, rumble]);
 
-  return (
-    <PlayArea>
-      {/* Timer bar */}
-      <div className="w-full h-2 bg-gray-700 mb-8">
-        <div
-          className="h-full bg-blue-500 transition-all duration-100"
-          style={{ width: `${timePercentage}%` }}
-        />
-      </div>
+	const timePercentage = (gameStatus.roundTimeRemaining / gameStatus.totalRoundTime) * 100;
 
-      <div className="mb-8 w-full flex flex-row justify-center">
-        <div className="absolute">
-          {/* Animation Effects */}
-          {animationEffects.map((effect) => (
-            <AnimationEffectRenderer
-              key={effect.id}
-              effect={effect}
-              onComplete={() => removeAnimationEffect(effect.id)}
-            />
-          ))}
-        </div>
-        <div className="text-2xl font-bold">Score: {gameStatus.currentScore}</div>
-      </div>
+	return (
+		<PlayArea>
+			{/* Timer bar */}
+			<div className='w-full h-2 bg-gray-700 mb-8'>
+				<div
+					className='h-full bg-blue-500 transition-all duration-100'
+					style={{width: `${timePercentage}%`}}
+				/>
+			</div>
 
-      <ButtonsLayout
-        sequence={gameStatus.currentSequence}
-        completedButtons={gameStatus.completedButtons}
-      />
+			<div className='mb-8 w-full flex flex-row justify-center'>
+				<div className='absolute'>
+					{/* Animation Effects */}
+					{animationEffects.map((effect) => (
+						<AnimationEffectRenderer
+							key={effect.id}
+							effect={effect}
+							onComplete={() => {
+								removeAnimationEffect(effect.id);
+							}}
+						/>
+					))}
+				</div>
+				<div className='text-2xl font-bold'>Score: {gameStatus.currentScore}</div>
+			</div>
 
-      <div className="mt-8 text-xl">
-        Press the highlighted button!
-      </div>
+			<ButtonsLayout
+				sequence={gameStatus.currentSequence}
+				completedButtons={gameStatus.completedButtons}
+			/>
 
-      {/* Screen Effects */}
-      <ScreenEffects
-        showErrorFlash={showErrorFlash}
-      />
+			<div className='mt-8 text-xl'>
+				Press the highlighted button!
+			</div>
 
-      {/* Confetti Celebration */}
-      {showConfetti && (
-        <ConfettiCelebration
-          onComplete={() => setShowConfetti(false)}
-        />
-      )}
-    </PlayArea>
-  );
+			{/* Screen Effects */}
+			<ScreenEffects
+				showErrorFlash={showErrorFlash}
+			/>
+
+			{/* Confetti Celebration */}
+			{showConfetti && (
+				<ConfettiCelebration
+					onComplete={() => {
+						setShowConfetti(false);
+					}}
+				/>
+			)}
+		</PlayArea>
+	);
 };
 
 export default GameScreen;

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,68 +1,69 @@
-import React from 'react';
+import type React from 'react';
 import clsx from 'clsx';
 import ControllerButton from './ControllerButton';
-import { useGamepad } from '../contexts/GamepadContext';
+import {useGamepad} from '../contexts/GamepadContext';
 import PlayArea from './PlayArea';
-import { H1 } from './Text';
+import {H1} from './Text';
 
-interface Props {
-  onStartGame: () => void;
-  onViewCredits: () => void;
-}
+type Props = {
+	onStartGame: () => void;
+	onViewCredits: () => void;
+};
 
-const MainMenu: React.FC<Props> = ({ onStartGame, onViewCredits }) => {
-  const { useButtonListener, isGamepadConnected } = useGamepad();
+const MainMenu: React.FC<Props> = ({onStartGame, onViewCredits}) => {
+	const {useButtonListener, isGamepadConnected} = useGamepad();
 
-  useButtonListener((button) => {
-    if (button === 'A') {
-      onStartGame();
-    }
-    if (button === 'Y') {
-      onViewCredits();
-    }
-  }, [onStartGame, onViewCredits]);
+	useButtonListener((button) => {
+		if (button === 'A') {
+			onStartGame();
+		}
 
-  return (
-    <PlayArea>
-      <H1>Controller tutor</H1>
+		if (button === 'Y') {
+			onViewCredits();
+		}
+	}, [onStartGame, onViewCredits]);
 
-      {!isGamepadConnected && (
-        <div className="mb-12 bg-yellow-900 rounded-lg p-6 max-w-md">
-          <div className="text-center space-y-4">
-            <h2 className="text-xl font-semibold text-yellow-400">🎮 Controller Required!</h2>
-            <div className="text-sm text-yellow-400 space-y-2">
-              <p>Connect your Xbox, PlayStation, or other compatible controller via USB or Bluetooth.</p>
-              <p>Then, press any button on your controller to activate it.</p>
-            </div>
-            <div className="mt-4 pt-4 border-t border-yellow-600">
-              <p className="text-xs text-yellow-300">
-                No controller?{' '}
-                <a
-                  href="https://github.com/domdomegg/controller-tutor"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-yellow-200 underline hover:text-white transition-colors"
-                >
-                  See the GitHub README for a brief demo video.
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+	return (
+		<PlayArea>
+			<H1>Controller tutor</H1>
 
-      <div className={clsx('space-y-6 text-xl', { 'opacity-50': !isGamepadConnected })}>
-        <div className="flex items-center">
-          <ControllerButton button="A" />
-          <span className="ml-4">Start</span>
-        </div>
-        <div className="flex items-center">
-          <ControllerButton button="Y" />
-          <span className="ml-4">Credits</span>
-        </div>
-      </div>
-    </PlayArea>
-  );
+			{!isGamepadConnected && (
+				<div className='mb-12 bg-yellow-900 rounded-lg p-6 max-w-md'>
+					<div className='text-center space-y-4'>
+						<h2 className='text-xl font-semibold text-yellow-400'>🎮 Controller Required!</h2>
+						<div className='text-sm text-yellow-400 space-y-2'>
+							<p>Connect your Xbox, PlayStation, or other compatible controller via USB or Bluetooth.</p>
+							<p>Then, press any button on your controller to activate it.</p>
+						</div>
+						<div className='mt-4 pt-4 border-t border-yellow-600'>
+							<p className='text-xs text-yellow-300'>
+								No controller?{' '}
+								<a
+									href='https://github.com/domdomegg/controller-tutor'
+									target='_blank'
+									rel='noopener noreferrer'
+									className='text-yellow-200 underline hover:text-white transition-colors'
+								>
+									See the GitHub README for a brief demo video.
+								</a>
+							</p>
+						</div>
+					</div>
+				</div>
+			)}
+
+			<div className={clsx('space-y-6 text-xl', {'opacity-50': !isGamepadConnected})}>
+				<div className='flex items-center'>
+					<ControllerButton button='A' />
+					<span className='ml-4'>Start</span>
+				</div>
+				<div className='flex items-center'>
+					<ControllerButton button='Y' />
+					<span className='ml-4'>Credits</span>
+				</div>
+			</div>
+		</PlayArea>
+	);
 };
 
 export default MainMenu;

--- a/src/components/PlayArea.tsx
+++ b/src/components/PlayArea.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
+import type React from 'react';
 import clsx from 'clsx';
 
 type Props = React.PropsWithChildren<{
-  className?: string;
+	className?: string;
 }>;
 
-const PlayArea: React.FC<Props> = ({ className, children }) => {
-  return (
-    <div className={clsx('flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white p-16', className)}>
-      {children}
-    </div>
-  );
+const PlayArea: React.FC<Props> = ({className, children}) => {
+	return (
+		<div className={clsx('flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white p-16', className)}>
+			{children}
+		</div>
+	);
 };
 
 export default PlayArea;

--- a/src/components/ResultsScreen.tsx
+++ b/src/components/ResultsScreen.tsx
@@ -1,83 +1,87 @@
-import React, { useEffect, useState } from 'react';
-import { useGamepad } from '../contexts/GamepadContext';
+import React, {useEffect, useState} from 'react';
+import {useGamepad} from '../contexts/GamepadContext';
 import ControllerButton from './ControllerButton';
 
-interface Props {
-  score: number;
-  onPlayAgain: () => void;
-  onViewCredits: () => void;
-}
+type Props = {
+	score: number;
+	onPlayAgain: () => void;
+	onViewCredits: () => void;
+};
 
 const RANK_THRESHOLDS = [
-  { min: 30000, rank: 'Pro-gamer', message: 'Incredible! You\'re a true controller master!' },
-  { min: 20000, rank: 'Expert', message: 'Outstanding performance! You\'ve mastered the controls!' },
-  { min: 15000, rank: 'Skilled', message: 'Great job! Your controller skills are impressive!' },
-  { min: 10000, rank: 'Intermediate', message: 'Well done! You\'re getting the hang of it!' },
-  { min: 8000, rank: 'Novice', message: 'Good effort! Keep practicing to improve!' },
-  { min: 4000, rank: 'Beginner', message: 'Nice try! Practice makes perfect!' },
-  { min: 0, rank: 'NPC', message: 'You\'ll get there one day!' },
+	{min: 30000, rank: 'Pro-gamer', message: 'Incredible! You\'re a true controller master!'},
+	{min: 20000, rank: 'Expert', message: 'Outstanding performance! You\'ve mastered the controls!'},
+	{min: 15000, rank: 'Skilled', message: 'Great job! Your controller skills are impressive!'},
+	{min: 10000, rank: 'Intermediate', message: 'Well done! You\'re getting the hang of it!'},
+	{min: 8000, rank: 'Novice', message: 'Good effort! Keep practicing to improve!'},
+	{min: 4000, rank: 'Beginner', message: 'Nice try! Practice makes perfect!'},
+	{min: 0, rank: 'NPC', message: 'You\'ll get there one day!'},
 ] as const;
 
-const ResultsScreen: React.FC<Props> = ({ score, onPlayAgain, onViewCredits }) => {
-  const { useButtonListener } = useGamepad();
+const ResultsScreen: React.FC<Props> = ({score, onPlayAgain, onViewCredits}) => {
+	const {useButtonListener} = useGamepad();
 
-  const [buttonsReady, setButtonsReady] = useState(false);
-  useEffect(() => {
-    setTimeout(() => setButtonsReady(true), 2500);
-  });
+	const [buttonsReady, setButtonsReady] = useState(false);
+	useEffect(() => {
+		setTimeout(() => {
+			setButtonsReady(true);
+		}, 2500);
+	});
 
-  // Find the appropriate rank and message based on score
-  const currentRank = RANK_THRESHOLDS.find((threshold) => score >= threshold.min) || RANK_THRESHOLDS[RANK_THRESHOLDS.length - 1];
+	// Find the appropriate rank and message based on score
+	const currentRank = RANK_THRESHOLDS.find((threshold) => score >= threshold.min) || RANK_THRESHOLDS[RANK_THRESHOLDS.length - 1];
 
-  // Handle gamepad input
-  useButtonListener((button) => {
-    if (!buttonsReady) {
-      return;
-    }
+	// Handle gamepad input
+	useButtonListener((button) => {
+		if (!buttonsReady) {
+			return;
+		}
 
-    if (button === 'A') {
-      onPlayAgain();
-    }
-    if (button === 'Y') {
-      onViewCredits();
-    }
-  }, [buttonsReady, onPlayAgain, onViewCredits]);
+		if (button === 'A') {
+			onPlayAgain();
+		}
 
-  return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white p-8">
-      <div className="text-4xl font-bold mb-8">Your score: {score}</div>
-      <h2 className="text-2xl text-center">{currentRank.message}</h2>
+		if (button === 'Y') {
+			onViewCredits();
+		}
+	}, [buttonsReady, onPlayAgain, onViewCredits]);
 
-      <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-lg my-12">
-        {RANK_THRESHOLDS.map((threshold, index) => (
-          <React.Fragment key={threshold.rank}>
-            <div className="text-right">
-              {index === 0 ? `${threshold.min}+`
-                : `${threshold.min}-${RANK_THRESHOLDS[index - 1].min}`}
-            </div>
-            <div className={score >= threshold.min ? 'text-blue-400' : ''}>
-              {threshold.rank}
-            </div>
-          </React.Fragment>
-        ))}
-      </div>
+	return (
+		<div className='flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white p-8'>
+			<div className='text-4xl font-bold mb-8'>Your score: {score}</div>
+			<h2 className='text-2xl text-center'>{currentRank.message}</h2>
 
-      {buttonsReady
-        ? (
-          <div className="space-y-4 flex flex-col items-center">
-            <div className="flex items-center">
-              <ControllerButton button="A" />
-              <span className="ml-2 text-xl">Play again</span>
-            </div>
-            <div className="flex items-center">
-              <ControllerButton button="Y" />
-              <span className="ml-2 text-xl">View credits</span>
-            </div>
-          </div>
-        )
-        : <div className="text-2xl font-bold mb-8 animate-pulse">Preparing next round...</div>}
-    </div>
-  );
+			<div className='grid grid-cols-2 gap-x-8 gap-y-2 text-lg my-12'>
+				{RANK_THRESHOLDS.map((threshold, index) => (
+					<React.Fragment key={threshold.rank}>
+						<div className='text-right'>
+							{index === 0
+								? `${threshold.min}+`
+								: `${threshold.min}-${RANK_THRESHOLDS[index - 1].min}`}
+						</div>
+						<div className={score >= threshold.min ? 'text-blue-400' : ''}>
+							{threshold.rank}
+						</div>
+					</React.Fragment>
+				))}
+			</div>
+
+			{buttonsReady
+				? (
+					<div className='space-y-4 flex flex-col items-center'>
+						<div className='flex items-center'>
+							<ControllerButton button='A' />
+							<span className='ml-2 text-xl'>Play again</span>
+						</div>
+						<div className='flex items-center'>
+							<ControllerButton button='Y' />
+							<span className='ml-2 text-xl'>View credits</span>
+						</div>
+					</div>
+				)
+				: <div className='text-2xl font-bold mb-8 animate-pulse'>Preparing next round...</div>}
+		</div>
+	);
 };
 
 export default ResultsScreen;

--- a/src/components/ScreenEffects.tsx
+++ b/src/components/ScreenEffects.tsx
@@ -1,27 +1,27 @@
-import React from 'react';
+import type React from 'react';
 
-interface Props {
-  showErrorFlash: boolean;
-}
+type Props = {
+	showErrorFlash: boolean;
+};
 
-const ScreenEffects: React.FC<Props> = ({ showErrorFlash }) => {
-  return (
-    <>
-      {/* Red vignette flash overlay */}
-      {showErrorFlash && (
-        <div className="fixed inset-0 pointer-events-none z-50">
-          <div
-            className="absolute inset-0 bg-red-500/30 animate-ping"
-            style={{ animationDuration: '2000ms', animationIterationCount: '1' }}
-          />
-          <div
-            className="absolute inset-0 bg-gradient-radial from-transparent via-transparent to-red-600/50 animate-pulse"
-            style={{ animationDuration: '2000ms', animationIterationCount: '1' }}
-          />
-        </div>
-      )}
-    </>
-  );
+const ScreenEffects: React.FC<Props> = ({showErrorFlash}) => {
+	return (
+		<>
+			{/* Red vignette flash overlay */}
+			{showErrorFlash && (
+				<div className='fixed inset-0 pointer-events-none z-50'>
+					<div
+						className='absolute inset-0 bg-red-500/30 animate-ping'
+						style={{animationDuration: '2000ms', animationIterationCount: '1'}}
+					/>
+					<div
+						className='absolute inset-0 bg-gradient-radial from-transparent via-transparent to-red-600/50 animate-pulse'
+						style={{animationDuration: '2000ms', animationIterationCount: '1'}}
+					/>
+				</div>
+			)}
+		</>
+	);
 };
 
 export default ScreenEffects;

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import type React from 'react';
 import clsx from 'clsx';
 
 type Props = React.PropsWithChildren<{
-  className?: string;
+	className?: string;
 }>;
 
-export const H1: React.FC<Props> = ({ className, children }) => {
-  return (
-    <h1 className={clsx('text-4xl font-bold mb-12', className)}>
-      {children}
-    </h1>
-  );
+export const H1: React.FC<Props> = ({className, children}) => {
+	return (
+		<h1 className={clsx('text-4xl font-bold mb-12', className)}>
+			{children}
+		</h1>
+	);
 };

--- a/src/contexts/GamepadContext.tsx
+++ b/src/contexts/GamepadContext.tsx
@@ -1,190 +1,204 @@
-import React, {
-  createContext, useContext, useEffect, useState, useMemo,
-  DependencyList
-  ,
+import {type DependencyList} from 'react';
+import type React from 'react';
+import {
+	createContext, useContext, useEffect, useState, useMemo,
 } from 'react';
-import { ButtonType, GamepadState } from '../types/game';
+import {type ButtonType, type GamepadState} from '../types/game';
 
 type ButtonCallback = (button: ButtonType) => void;
 
-interface GamepadContextType {
-  isGamepadConnected: boolean;
-  useButtonListener: (callback: ButtonCallback, deps: DependencyList) => void;
-  rumble: () => void;
-}
-
-const GamepadContext = createContext<GamepadContextType>({
-  isGamepadConnected: false,
-  useButtonListener: () => {},
-  rumble: () => {},
-});
-
-interface Props {
-  children: React.ReactNode;
-}
-
-const mapGamepadToGamepadState = (gamepad: Gamepad, deadzone = 0.5): GamepadState => {
-  const { axes, buttons } = gamepad;
-
-  return {
-    buttons: {
-      A: buttons[0].pressed,
-      B: buttons[1].pressed,
-      X: buttons[2].pressed,
-      Y: buttons[3].pressed,
-      LB: buttons[4].pressed,
-      RB: buttons[5].pressed,
-      LT: buttons[6].pressed,
-      RT: buttons[7].pressed,
-      View: buttons[8].pressed,
-      Menu: buttons[9].pressed,
-      LS: buttons[10].pressed,
-      RS: buttons[11].pressed,
-      DUp: buttons[12].pressed,
-      DDown: buttons[13].pressed,
-      DLeft: buttons[14].pressed,
-      DRight: buttons[15].pressed,
-      Xbox: buttons[16].pressed,
-
-      LUp: axes[1] < -deadzone,
-      LDown: axes[1] > deadzone,
-      LLeft: axes[0] < -deadzone,
-      LRight: axes[0] > deadzone,
-      RUp: axes[3] < -deadzone,
-      RDown: axes[3] > deadzone,
-      RLeft: axes[2] < -deadzone,
-      RRight: axes[2] > deadzone,
-    },
-    axes: {
-      L: {
-        x: axes[0],
-        y: axes[1],
-      },
-      R: {
-        x: axes[2],
-        y: axes[3],
-      },
-    },
-  };
+type GamepadContextType = {
+	isGamepadConnected: boolean;
+	useButtonListener: (callback: ButtonCallback, deps: DependencyList) => void;
+	rumble: () => void;
 };
 
-export const GamepadProvider: React.FC<Props> = ({ children }) => {
-  const [gamepadIndex, setGamepadIndex] = useState<number | null>(null);
-  const [buttonStates, setButtonStates] = useState<{
-    current: Set<ButtonType>;
-    previous: Set<ButtonType>;
-  }>({
-    current: new Set(),
-    previous: new Set(),
-  });
-  const [buttonCallbacks] = useState<Set<ButtonCallback>>(new Set());
+const GamepadContext = createContext<GamepadContextType>({
+	isGamepadConnected: false,
+	useButtonListener() {
+		// No-op default; overridden by the provider.
+	},
+	rumble() {
+		// No-op default; overridden by the provider.
+	},
+});
 
-  useEffect(() => {
-    const handleGamepadConnected = (e: GamepadEvent) => {
-      console.log('Gamepad connected:', e.gamepad);
-      setGamepadIndex(e.gamepad.index);
-    };
+type Props = {
+	children: React.ReactNode;
+};
 
-    const handleGamepadDisconnected = (e: GamepadEvent) => {
-      console.log('Gamepad disconnected:', e.gamepad);
-      if (e.gamepad.index === gamepadIndex) {
-        setGamepadIndex(null);
-      }
-    };
+const mapGamepadToGamepadState = (gamepad: Gamepad, deadzone = 0.5): GamepadState => {
+	const {axes, buttons} = gamepad;
 
-    window.addEventListener('gamepadconnected', handleGamepadConnected);
-    window.addEventListener('gamepaddisconnected', handleGamepadDisconnected);
+	return {
+		buttons: {
+			A: buttons[0].pressed,
+			B: buttons[1].pressed,
+			X: buttons[2].pressed,
+			Y: buttons[3].pressed,
+			LB: buttons[4].pressed,
+			RB: buttons[5].pressed,
+			LT: buttons[6].pressed,
+			RT: buttons[7].pressed,
+			View: buttons[8].pressed,
+			Menu: buttons[9].pressed,
+			LS: buttons[10].pressed,
+			RS: buttons[11].pressed,
+			DUp: buttons[12].pressed,
+			DDown: buttons[13].pressed,
+			DLeft: buttons[14].pressed,
+			DRight: buttons[15].pressed,
+			Xbox: buttons[16].pressed,
 
-    return () => {
-      window.removeEventListener('gamepadconnected', handleGamepadConnected);
-      window.removeEventListener('gamepaddisconnected', handleGamepadDisconnected);
-    };
-  }, [gamepadIndex]);
+			LUp: axes[1] < -deadzone,
+			LDown: axes[1] > deadzone,
+			LLeft: axes[0] < -deadzone,
+			LRight: axes[0] > deadzone,
+			RUp: axes[3] < -deadzone,
+			RDown: axes[3] > deadzone,
+			RLeft: axes[2] < -deadzone,
+			RRight: axes[2] > deadzone,
+		},
+		axes: {
+			L: {
+				x: axes[0],
+				y: axes[1],
+			},
+			R: {
+				x: axes[2],
+				y: axes[3],
+			},
+		},
+	};
+};
 
-  useEffect(() => {
-    if (gamepadIndex === null) return undefined;
+export const GamepadProvider: React.FC<Props> = ({children}) => {
+	const [gamepadIndex, setGamepadIndex] = useState<number | null>(null);
+	const [buttonStates, setButtonStates] = useState<{
+		current: Set<ButtonType>;
+		previous: Set<ButtonType>;
+	}>({
+		current: new Set(),
+		previous: new Set(),
+	});
+	const [buttonCallbacks] = useState<Set<ButtonCallback>>(new Set());
 
-    const pollGamepad = () => {
-      const gamepads = navigator.getGamepads();
-      const gamepad = gamepads[gamepadIndex];
-      if (!gamepad) return;
+	useEffect(() => {
+		const handleGamepadConnected = (e: GamepadEvent) => {
+			console.log('Gamepad connected:', e.gamepad);
+			setGamepadIndex(e.gamepad.index);
+		};
 
-      const newCurrentButtons = new Set<ButtonType>();
+		const handleGamepadDisconnected = (e: GamepadEvent) => {
+			console.log('Gamepad disconnected:', e.gamepad);
+			if (e.gamepad.index === gamepadIndex) {
+				setGamepadIndex(null);
+			}
+		};
 
-      const gamepadState = mapGamepadToGamepadState(gamepad);
+		window.addEventListener('gamepadconnected', handleGamepadConnected);
+		window.addEventListener('gamepaddisconnected', handleGamepadDisconnected);
 
-      Object.entries(gamepadState.buttons).forEach(([button, pressed]) => {
-        if (pressed) newCurrentButtons.add(button as ButtonType);
-      });
+		return () => {
+			window.removeEventListener('gamepadconnected', handleGamepadConnected);
+			window.removeEventListener('gamepaddisconnected', handleGamepadDisconnected);
+		};
+	}, [gamepadIndex]);
 
-      setButtonStates((prev) => ({
-        previous: prev.current,
-        current: newCurrentButtons,
-      }));
-    };
+	useEffect(() => {
+		if (gamepadIndex === null) {
+			return undefined;
+		}
 
-    const intervalId = setInterval(pollGamepad, 16); // ~60fps
+		const pollGamepad = () => {
+			const gamepads = navigator.getGamepads();
+			const gamepad = gamepads[gamepadIndex];
+			if (!gamepad) {
+				return;
+			}
 
-    return () => clearInterval(intervalId);
-  }, [gamepadIndex]);
+			const newCurrentButtons = new Set<ButtonType>();
 
-  // Calculate newly pressed buttons (buttons that are pressed now but weren't before)
-  const newlyPressedButtons = useMemo(() => {
-    const newButtons = new Set<ButtonType>();
-    buttonStates.current.forEach((button) => {
-      if (!buttonStates.previous.has(button)) {
-        newButtons.add(button);
-      }
-    });
-    return newButtons;
-  }, [buttonStates]);
+			const gamepadState = mapGamepadToGamepadState(gamepad);
 
-  // Notify callbacks of newly pressed buttons
-  useEffect(() => {
-    newlyPressedButtons.forEach((button) => {
-      buttonCallbacks.forEach((callback) => {
-        callback(button);
-      });
-    });
-  }, [newlyPressedButtons, buttonCallbacks]);
+			Object.entries(gamepadState.buttons).forEach(([button, pressed]) => {
+				if (pressed) {
+					newCurrentButtons.add(button as ButtonType);
+				}
+			});
 
-  const useButtonListener = (callback: ButtonCallback, deps: DependencyList) => {
-    useEffect(() => {
-      buttonCallbacks.add(callback);
-      return () => {
-        buttonCallbacks.delete(callback);
-      };
-    }, [buttonCallbacks, ...deps]);
-  };
+			setButtonStates((prev) => ({
+				previous: prev.current,
+				current: newCurrentButtons,
+			}));
+		};
 
-  const rumble = () => {
-    if (gamepadIndex === null) return;
+		const intervalId = setInterval(pollGamepad, 16); // ~60fps
 
-    const gamepads = navigator.getGamepads();
-    const gamepad = gamepads[gamepadIndex];
+		return () => {
+			clearInterval(intervalId);
+		};
+	}, [gamepadIndex]);
 
-    if (gamepad && gamepad.vibrationActuator) {
-      gamepad.vibrationActuator.playEffect('dual-rumble', {
-        duration: 200,
-        strongMagnitude: 0.7,
-        weakMagnitude: 0.7,
-      }).catch((error) => {
-        console.warn('Rumble not supported or failed:', error);
-      });
-    }
-  };
+	// Calculate newly pressed buttons (buttons that are pressed now but weren't before)
+	const newlyPressedButtons = useMemo(() => {
+		const newButtons = new Set<ButtonType>();
+		buttonStates.current.forEach((button) => {
+			if (!buttonStates.previous.has(button)) {
+				newButtons.add(button);
+			}
+		});
+		return newButtons;
+	}, [buttonStates]);
 
-  const contextValue = useMemo(() => ({
-    isGamepadConnected: gamepadIndex !== null,
-    useButtonListener,
-    rumble,
-  }), [gamepadIndex, buttonCallbacks]);
+	// Notify callbacks of newly pressed buttons
+	useEffect(() => {
+		newlyPressedButtons.forEach((button) => {
+			buttonCallbacks.forEach((callback) => {
+				callback(button);
+			});
+		});
+	}, [newlyPressedButtons, buttonCallbacks]);
 
-  return (
-    <GamepadContext.Provider value={contextValue}>
-      {children}
-    </GamepadContext.Provider>
-  );
+	const useButtonListener = (callback: ButtonCallback, deps: DependencyList) => {
+		useEffect(() => {
+			buttonCallbacks.add(callback);
+			return () => {
+				buttonCallbacks.delete(callback);
+			};
+		}, [buttonCallbacks, ...deps]);
+	};
+
+	const rumble = () => {
+		if (gamepadIndex === null) {
+			return;
+		}
+
+		const gamepads = navigator.getGamepads();
+		const gamepad = gamepads[gamepadIndex];
+
+		if (gamepad?.vibrationActuator) {
+			gamepad.vibrationActuator.playEffect('dual-rumble', {
+				duration: 200,
+				strongMagnitude: 0.7,
+				weakMagnitude: 0.7,
+			}).catch((error: unknown) => {
+				console.warn('Rumble not supported or failed:', error);
+			});
+		}
+	};
+
+	const contextValue = useMemo(() => ({
+		isGamepadConnected: gamepadIndex !== null,
+		useButtonListener,
+		rumble,
+	}), [gamepadIndex, buttonCallbacks]);
+
+	return (
+		<GamepadContext.Provider value={contextValue}>
+			{children}
+		</GamepadContext.Provider>
+	);
 };
 
 export const useGamepad = () => useContext(GamepadContext);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,13 @@
-import type { AppProps } from 'next/app';
-import { GamepadProvider } from '../contexts/GamepadContext';
+import type {AppProps} from 'next/app';
+import {GamepadProvider} from '../contexts/GamepadContext';
 import '../styles/globals.css';
 
-const App = ({ Component, pageProps }: AppProps) => {
-  return (
-    <GamepadProvider>
-      <Component {...pageProps} />
-    </GamepadProvider>
-  );
+const App = ({Component, pageProps}: AppProps) => {
+	return (
+		<GamepadProvider>
+			<Component {...pageProps} />
+		</GamepadProvider>
+	);
 };
 
 export default App;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,17 +1,17 @@
 import {
-  Html, Head, Main, NextScript,
+	Html, Head, Main, NextScript,
 } from 'next/document';
 
 const Document = () => {
-  return (
-    <Html lang="en">
-      <Head />
-      <body className="antialiased">
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+	return (
+		<Html lang='en'>
+			<Head />
+			<body className='antialiased'>
+				<Main />
+				<NextScript />
+			</body>
+		</Html>
+	);
 };
 
 export default Document;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,46 +1,56 @@
-import { useState } from 'react';
+import {useState} from 'react';
 import MainMenu from '../components/MainMenu';
 import GameScreen from '../components/GameScreen';
 import ResultsScreen from '../components/ResultsScreen';
 import CreditsScreen from '../components/CreditsScreen';
-import { GameView } from '../types/game';
+import {type GameView} from '../types/game';
 
 const Home = () => {
-  const [gameView, setGameView] = useState<GameView>('menu');
-  const [score, setScore] = useState(0);
+	const [gameView, setGameView] = useState<GameView>('menu');
+	const [score, setScore] = useState(0);
 
-  const handleGameOver = (finalScore: number) => {
-    setScore(finalScore);
-    setGameView('results');
-  };
+	const handleGameOver = (finalScore: number) => {
+		setScore(finalScore);
+		setGameView('results');
+	};
 
-  return (
-    <main className="min-h-screen bg-gray-900">
-      {gameView === 'menu' && (
-        <MainMenu
-          onStartGame={() => setGameView('game')}
-          onViewCredits={() => setGameView('credits')}
-        />
-      )}
-      {gameView === 'game' && (
-        <GameScreen
-          onGameOver={handleGameOver}
-        />
-      )}
-      {gameView === 'results' && (
-        <ResultsScreen
-          score={score}
-          onPlayAgain={() => setGameView('game')}
-          onViewCredits={() => setGameView('credits')}
-        />
-      )}
-      {gameView === 'credits' && (
-        <CreditsScreen
-          onBackToMenu={() => setGameView('menu')}
-        />
-      )}
-    </main>
-  );
+	return (
+		<main className='min-h-screen bg-gray-900'>
+			{gameView === 'menu' && (
+				<MainMenu
+					onStartGame={() => {
+						setGameView('game');
+					}}
+					onViewCredits={() => {
+						setGameView('credits');
+					}}
+				/>
+			)}
+			{gameView === 'game' && (
+				<GameScreen
+					onGameOver={handleGameOver}
+				/>
+			)}
+			{gameView === 'results' && (
+				<ResultsScreen
+					score={score}
+					onPlayAgain={() => {
+						setGameView('game');
+					}}
+					onViewCredits={() => {
+						setGameView('credits');
+					}}
+				/>
+			)}
+			{gameView === 'credits' && (
+				<CreditsScreen
+					onBackToMenu={() => {
+						setGameView('menu');
+					}}
+				/>
+			)}
+		</main>
+	);
 };
 
 export default Home;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,53 +1,53 @@
 export type GameView = 'menu' | 'game' | 'results' | 'credits';
 
 export type GamepadState = {
-  buttons: {
-    A: boolean,
-    B: boolean,
-    X: boolean,
-    Y: boolean,
-    LB: boolean,
-    RB: boolean,
-    LT: boolean,
-    RT: boolean,
-    View: boolean,
-    Menu: boolean,
-    LS: boolean,
-    RS: boolean,
-    DUp: boolean,
-    DDown: boolean,
-    DLeft: boolean,
-    DRight: boolean,
-    Xbox: boolean,
+	buttons: {
+		A: boolean;
+		B: boolean;
+		X: boolean;
+		Y: boolean;
+		LB: boolean;
+		RB: boolean;
+		LT: boolean;
+		RT: boolean;
+		View: boolean;
+		Menu: boolean;
+		LS: boolean;
+		RS: boolean;
+		DUp: boolean;
+		DDown: boolean;
+		DLeft: boolean;
+		DRight: boolean;
+		Xbox: boolean;
 
-    // Virtual buttons, based on joystick position
-    LUp: boolean,
-    LDown: boolean,
-    LLeft: boolean,
-    LRight: boolean,
-    RUp: boolean,
-    RDown: boolean,
-    RLeft: boolean,
-    RRight: boolean,
-  },
-  axes: {
-    L: {
-      x: number,
-      y: number,
-    },
-    R: {
-      x: number,
-      y: number,
-    },
-  }
+		// Virtual buttons, based on joystick position
+		LUp: boolean;
+		LDown: boolean;
+		LLeft: boolean;
+		LRight: boolean;
+		RUp: boolean;
+		RDown: boolean;
+		RLeft: boolean;
+		RRight: boolean;
+	};
+	axes: {
+		L: {
+			x: number;
+			y: number;
+		};
+		R: {
+			x: number;
+			y: number;
+		};
+	};
 };
 
 export type ButtonType = keyof GamepadState['buttons'];
 
 export type GameStatus = {
-  currentScore: number;
-  currentSequence: ButtonType[];
-  completedButtons: ButtonType[];
-  totalRoundTime: number;
-  roundTimeRemaining: number;
+	currentScore: number;
+	currentSequence: ButtonType[];
+	completedButtons: ButtonType[];
+	totalRoundTime: number;
+	roundTimeRemaining: number;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,28 +1,28 @@
-import type { Config } from 'tailwindcss';
+import type {Config} from 'tailwindcss';
 
 const config: Config = {
-  content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
-  theme: {
-    extend: {
-      colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
-      },
-      animation: {
-        breathe: 'breathe 2s ease-in-out infinite',
-      },
-      keyframes: {
-        breathe: {
-          '0%, 100%': { transform: 'scale(1)' },
-          '50%': { transform: 'scale(1.15)' },
-        },
-      },
-    },
-  },
-  plugins: [],
+	content: [
+		'./src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+		'./src/components/**/*.{js,ts,jsx,tsx,mdx}',
+		'./src/app/**/*.{js,ts,jsx,tsx,mdx}',
+	],
+	theme: {
+		extend: {
+			colors: {
+				background: 'var(--background)',
+				foreground: 'var(--foreground)',
+			},
+			animation: {
+				breathe: 'breathe 2s ease-in-out infinite',
+			},
+			keyframes: {
+				breathe: {
+					'0%, 100%': {transform: 'scale(1)'},
+					'50%': {transform: 'scale(1.15)'},
+				},
+			},
+		},
+	},
+	plugins: [],
 };
 export default config;


### PR DESCRIPTION
Migrates from `eslint-config-domdomegg` v1 (legacy `.eslintrc`) to **v2 flat config**.

## What changed
- Replaced `.eslintrc.json` with a flat `eslint.config.mjs` (ESM, tabs).
- Bumped `eslint` to `^9.0.0` (the preset peers `eslint ^9`) and confirmed `eslint-config-domdomegg` at `^2.0.9`.
- Ported the **Next.js framework config**: the old `extends` of `next/core-web-vitals` + `next/typescript` is now provided via `@next/eslint-plugin-next`'s flat `recommended` + `core-web-vitals` rule sets (matching the repo's Next 16). Replaced the stale `eslint-config-next@15.0.2` devDependency with `@next/eslint-plugin-next@^16.2.6`.
- Ported the repo's custom rule override: `react-hooks/exhaustive-deps` with `additionalHooks: "(useButtonListener)"`, kept as a `warn` (after the spread).
- Added `ignores` for Next build output (`.next/**`, `out/**`) and the generated `next-env.d.ts` — the old `lint` script was scoped to `src/`, so this keeps the new repo-wide `eslint` from linting generated/build artifacts.
- `lint` script simplified to `"eslint"`.
- Ran `eslint --fix`: the large source diff is **entirely mechanical reindentation** (spaces→tabs, `interface`→`type`, single-quote JSX, `import type`) — no logic changes.

The old config had no `ignorePatterns` or `env` settings to port.

## A few genuine (trivial) fixes surfaced by the stricter preset
Not autofixable, resolved the right way (no blanket rule disables):
- `ConfettiCelebration.tsx`: added clarifying parentheses for mixed `*`/`+`/`-` operator precedence (`no-mixed-operators`).
- `GamepadContext.tsx`: optional chaining (`gamepad?.vibrationActuator`), `: unknown` catch variable, and explanatory no-op comments on the two default-context stub methods.

## Status
- **Lint:** clean (0 errors, exit 0). 5 pre-existing `react-hooks/exhaustive-deps` **warnings** remain — non-blocking, matching the old config's `warn` intent.
- **Build:** `npm run build` passes (Next 16 + TypeScript compile clean).
- **Tests:** no test script in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)